### PR TITLE
small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ build/
 *.exe
 *.z64
 /.vs
-patch/

--- a/lib/libpm-jp.a
+++ b/lib/libpm-jp.a
@@ -1,4 +1,5 @@
 osSyncPrintf = 0x80025CFC;
+pm_main_game_hook = 0x80026C88;
 pm_FioValidateFileChecksum = 0x8002B0B8;
 pm_FioFetchSavedFileInfo = 0x8002B114;
 pm_FioDeserializeState = 0x8002B450;
@@ -43,4 +44,3 @@ pm_ActionCommandState = 0x8029FF14;
 pm_func_802A472C = 0x802A4608;
 pm_curr_script_lst = 0x802DA890;
 pm_SaveGame = 0x802DC150;
-pm_main_game_hook = 0x80026C88;

--- a/lib/libpm-us.a
+++ b/lib/libpm-us.a
@@ -1,4 +1,5 @@
 osSyncPrintf = 0x80025CFC;
+pm_main_game_hook = 0x80026CBC;
 pm_FioValidateFileChecksum = 0x8002B0F8;
 pm_FioFetchSavedFileInfo = 0x8002B154;
 pm_FioDeserializeState = 0x8002B490;
@@ -43,4 +44,3 @@ pm_ActionCommandState = 0x8029FC24;
 pm_func_802A472C = 0x802A472C;
 pm_curr_script_lst = 0x802DA890;
 pm_SaveGame = 0x802E11A0;
-pm_main_game_hook = 0x80026CBC;

--- a/lua/make.lua
+++ b/lua/make.lua
@@ -27,7 +27,7 @@ end
 local hooks = gru.gsc_load("build/patch/" .. fp_version .. "/hooks.gsc")
 
 print("Applying hooks")
-hooks:shift(-rom_info.code_ram)
+hooks:shift(-rom_info.rom_to_ram)
 hooks:apply_be(rom)
 
 local old_ldr = rom:copy(rom_info.ldr_rom, 0x54)
@@ -36,12 +36,12 @@ local payload_rom = 0x2800000
 local fp_rom = payload_rom + 0x60
 
 print("Building Loader")
-print(string.format("make CPPFLAGS=' -DDMA=0x%08x -DEND=0x%08x' LDFLAGS=' -Wl,--defsym,start=0x%08x'" ..
+print(string.format("make CPPFLAGS=' -DDMA_COPY=0x%08x -DEND=0x%08x' LDFLAGS=' -Wl,--defsym,start=0x%08x'" ..
                     " ldr-" .. fp_version, 
                     rom_info.dma_func,
                     fp:size() + fp_rom,
                     rom_info.ldr_addr))
-local _,_,res = os.execute(string.format("make CPPFLAGS=' -DDMA=0x%08x -DEND=0x%08x' LDFLAGS=' -Wl,--defsym,start=0x%08x'" ..
+local _,_,res = os.execute(string.format("make CPPFLAGS=' -DDMA_COPY=0x%08x -DEND=0x%08x' LDFLAGS=' -Wl,--defsym,start=0x%08x'" ..
                                          " ldr-" .. fp_version, 
                                          rom_info.dma_func,
                                          fp:size() + fp_rom,

--- a/lua/rom_info.lua
+++ b/lua/rom_info.lua
@@ -1,13 +1,13 @@
 roms = {
     [0xBD60CA66] = {
-        code_ram = 0x80024C00,
+        rom_to_ram = 0x80024C00,
         ldr_rom = 0x25E2C,
         ldr_addr = 0x8004AA2C,
         dma_func = 0x800296FC,
         rom_id = "JP",
     },
     [0xA7F5CD7E] = {
-        code_ram = 0x80024C00,
+        rom_to_ram = 0x80024C00,
         ldr_rom = 0x2617C,
         ldr_addr = 0x8004AD7C,
         dma_func = 0x8002973C,

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ FP_VERSIONS    = JP US
 NAME           = fp
 NDEBUG        ?= 0
 
-ADDRESS_FP_BIN = 0x80400060
+FP_BIN_ADDRESS = 0x80400060
 CFLAGS         = -c -MMD -MP -std=gnu11 -Wall -ffunction-sections -fdata-sections -O1 -fno-reorder-blocks
 ALL_CPPFLAGS   = -DPACKAGE=$(PACKAGE) -DURL=$(URL) -DF3DEX_GBI_2 $(CPPFLAGS)
 ALL_LDFLAGS    = -T gl-n64.ld -L$(LIBDIR) -nostartfiles -specs=nosys.specs -Wl,--gc-sections $(LDFLAGS)
@@ -86,8 +86,8 @@ endef
 $(foreach v,$(FP_VERSIONS),$(eval $(call bin_template,fp-$(v),$(v),fp,src,res/fp)))
 $(foreach v,$(FP_VERSIONS),$(eval $(call bin_template,ldr-fp-$(v),$(v),ldr,src/asm,res/ldr)))
 
-$(FP-US)	:	ALL_LDFLAGS	+=	-Wl,-Map=$(BUILDDIR)/fp-us.map -Wl,--defsym,start=$(ADDRESS_FP_BIN)
-$(FP-JP)	:	ALL_LDFLAGS	+=	-Wl,-Map=$(BUILDDIR)/fp-jp.map -Wl,--defsym,start=$(ADDRESS_FP_BIN)
+$(FP-US)	:	ALL_LDFLAGS	+=	-Wl,-Map=$(BUILDDIR)/fp-us.map -Wl,--defsym,start=$(FP_BIN_ADDRESS)
+$(FP-JP)	:	ALL_LDFLAGS	+=	-Wl,-Map=$(BUILDDIR)/fp-jp.map -Wl,--defsym,start=$(FP_BIN_ADDRESS)
 
 $(FP-US)	:	LIBS	:=	-lpm-us
 $(FP-JP)	:	LIBS	:=	-lpm-jp

--- a/src/asm/ldr.s
+++ b/src/asm/ldr.s
@@ -9,7 +9,7 @@ _start:
 li  $a0, 0x2800000
 li  $a1, (END)
 lui $a2, 0x8040
-jal (DMA)
+jal (DMA_COPY)
 j 0x80400000
 nop
 nop
@@ -22,6 +22,6 @@ nop
 nop
 nop
 nop
-nop // last instruction of the function that was originally here
+nop
 .end _start
 .size _start, . - _start


### PR DESCRIPTION
-remove uneeded line from ignore
-put game hook in address order in both libs
-in the lua file `code_ram` is a zelda thing, cause it has a massive binary file called "code". I renamed it to what we use it for here, just a rom to ram conversion
-DMA -> DMA_COPY just to follow what decomp calls that function
-removed a comment i added in ldr.s. I didnt intend for it to stay there
-ADDRESS_FP_BIN -> FP_BIN_ADDRESS. it made sense before when we had other address defines, but now since its the only one we can say it in the intuitive order